### PR TITLE
Add Dynamics connection logic

### DIFF
--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -1,7 +1,19 @@
 from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from pathlib import Path
+
 from .controllers.incidents_controller import router as incidents_router
 
 app = FastAPI(title="MCP Server Dynamics 365 Customer Service")
 
+# Path to repository root so we can serve the OpenAPI manifest
+BASE_DIR = Path(__file__).resolve().parent.parent
+
 app.include_router(incidents_router, prefix="/incident", tags=["Incident Management"])
+
+
+@app.get("/openapi.yaml", include_in_schema=False)
+async def serve_openapi_spec() -> FileResponse:
+    """Expose the OpenAPI document for MCP registration."""
+    return FileResponse(BASE_DIR / "openapi.yaml", media_type="application/yaml")
 

--- a/mcp_server/utils/auth_dynamics.py
+++ b/mcp_server/utils/auth_dynamics.py
@@ -1,27 +1,61 @@
 """Utility functions for authenticating against Dynamics 365 via OAuth."""
 
 import time
-from pydantic import BaseModel
 from typing import Optional
 
+import httpx
+from pydantic import BaseModel
+
 from ..config.settings import get_settings
+
 
 class Token(BaseModel):
     access_token: str
     expires_at: float
 
-# In a real implementation this would retrieve a token from Azure AD.
-# Here we mock the behaviour for example purposes.
+
 _token_cache: Optional[Token] = None
 
+
 async def get_access_token() -> str:
+    """Retrieve an OAuth token from Azure AD using client credentials."""
     global _token_cache
+
     if _token_cache and _token_cache.expires_at > time.time():
         return _token_cache.access_token
 
     settings = get_settings()
-    # TODO: implement real OAuth retrieval using aiohttp or httpx.
-    # For now we return a placeholder token.
-    access_token = "fake-token"
-    _token_cache = Token(access_token=access_token, expires_at=time.time() + 3600)
+    if not all(
+        [
+            settings.dynamics_tenant_id,
+            settings.dynamics_client_id,
+            settings.dynamics_client_secret,
+            settings.dynamics_resource,
+        ]
+    ):
+        # In development or test environments credentials may be absent.
+        access_token = "fake-token"
+        _token_cache = Token(access_token=access_token, expires_at=time.time() + 3600)
+        return access_token
+    token_url = (
+        f"https://login.microsoftonline.com/{settings.dynamics_tenant_id}/oauth2/v2.0/token"
+    )
+    data = {
+        "client_id": settings.dynamics_client_id,
+        "client_secret": settings.dynamics_client_secret,
+        "grant_type": "client_credentials",
+        "scope": f"{settings.dynamics_resource}/.default",
+    }
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(token_url, data=data)
+        resp.raise_for_status()
+        payload = resp.json()
+
+    access_token = payload["access_token"]
+    expires_in = int(payload.get("expires_in", 3599))
+    _token_cache = Token(
+        access_token=access_token,
+        expires_at=time.time() + expires_in - 60,
+    )
     return access_token

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,141 @@
+openapi: 3.0.3
+info:
+  title: Dynamics 365 Incident MCP API
+  version: '1.0'
+  description: API for Dynamics 365 Customer Service incidents using MCP
+servers:
+  - url: http://localhost:8000
+paths:
+  /incident/create:
+    post:
+      summary: Create a new incident
+      operationId: createIncident
+      tags:
+        - Incident Management
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentCreateRequest'
+      responses:
+        '200':
+          description: Incident created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncidentResponse'
+  /incident/status:
+    post:
+      summary: Get the status of an incident
+      operationId: incidentStatus
+      tags:
+        - Incident Management
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentStatusRequest'
+      responses:
+        '200':
+          description: Incident status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncidentStatusResponse'
+  /incident/update:
+    post:
+      summary: Update an incident
+      operationId: updateIncident
+      tags:
+        - Incident Management
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentUpdateRequest'
+      responses:
+        '200':
+          description: Incident updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncidentResponse'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    IncidentCreateRequest:
+      type: object
+      properties:
+        userId:
+          type: string
+        description:
+          type: string
+      required:
+        - userId
+        - description
+    IncidentStatusRequest:
+      type: object
+      properties:
+        incidentId:
+          type: string
+      required:
+        - incidentId
+    IncidentUpdateRequest:
+      type: object
+      properties:
+        incidentId:
+          type: string
+        updateDetails:
+          type: string
+      required:
+        - incidentId
+        - updateDetails
+    IncidentResponse:
+      type: object
+      properties:
+        incidentId:
+          type: string
+        status:
+          type: string
+        message:
+          type: string
+      required:
+        - incidentId
+        - status
+        - message
+    IncidentStatusResponse:
+      type: object
+      properties:
+        incidentId:
+          type: string
+        status:
+          type: string
+        detail:
+          type: string
+      required:
+        - incidentId
+        - status
+        - detail
+security:
+  - bearerAuth: []
+x-ms-copilot:
+  authentication:
+    type: oauth2
+    provider: azureAD
+  actions:
+    - name: createIncident
+      description: Create a new incident for a user
+      operationId: createIncident
+    - name: incidentStatus
+      description: Get the status for a specific incident
+      operationId: incidentStatus
+    - name: updateIncident
+      description: Update the details of an incident
+      operationId: updateIncident

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,11 @@
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from mcp_server.main import app
 
 @pytest.mark.asyncio
 async def test_create_incident():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
             "/incident/create",
             json={"userId": "1", "description": "Test"},
@@ -16,7 +17,8 @@ async def test_create_incident():
 
 @pytest.mark.asyncio
 async def test_status_incident():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
             "/incident/status",
             json={"incidentId": "1"},
@@ -28,7 +30,8 @@ async def test_status_incident():
 
 @pytest.mark.asyncio
 async def test_update_incident():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
             "/incident/update",
             json={"incidentId": "1", "updateDetails": "update"},


### PR DESCRIPTION
## Summary
- add OAuth token retrieval with httpx and safe fallbacks
- connect to Dynamics API in service layer when configuration is provided
- adjust tests to use ASGITransport

## Testing
- `pip install -r requirements.txt`
- `python -m openapi_spec_validator openapi.yaml`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845aa33e1fc832695fe2b448ed6f733