### PR TITLE
Integrate MCP FastMCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # mcp-Dynamics365-Customer-Service
 
-This project provides a minimal MCP (Microsoft Copilot Protocol) server that acts as an intermediary between Copilot Studio and Dynamics 365 Customer Service.
+This project now includes a server built with the
+[Model Context Protocol](https://modelcontextprotocol.io) Python SDK.
+It acts as an intermediary between Copilot Studio and Dynamics 365 Customer Service.
 
 ## Requirements
 - Python 3.10+
@@ -12,10 +14,19 @@ pip install -r requirements.txt
 ```
 
 ## Running the server
+The project exposes both the original FastAPI implementation and an MCP server
+using the Python SDK.
+
+### FastAPI
 ```bash
 uvicorn mcp_server.main:app --reload
 ```
 The API will be available at `http://localhost:8000`.
+
+### MCP Server
+```bash
+mcp run mcp_server/mcp_server.py
+```
 
 ## Endpoints
 - `POST /incident/create`

--- a/mcp_server/mcp_server.py
+++ b/mcp_server/mcp_server.py
@@ -1,0 +1,41 @@
+from mcp.server.fastmcp import FastMCP
+
+from .services.dynamics_service import (
+    create_incident_in_dynamics,
+    get_incident_status,
+    update_incident,
+)
+
+mcp = FastMCP("Dynamics 365 Customer Service")
+
+
+@mcp.tool()
+async def create_incident(userId: str, description: str) -> dict:
+    """Create a new incident in Dynamics 365."""
+    incident_id = await create_incident_in_dynamics(userId, description)
+    return {
+        "incidentId": incident_id,
+        "status": "Creado",
+        "message": "Incidencia registrada correctamente.",
+    }
+
+
+@mcp.tool()
+async def incident_status(incidentId: str) -> dict:
+    """Get the status for an incident."""
+    return await get_incident_status(incidentId)
+
+
+@mcp.tool(name="update_incident")
+async def incident_update(incidentId: str, updateDetails: str) -> dict:
+    """Update an existing incident."""
+    await update_incident(incidentId, updateDetails)
+    return {
+        "incidentId": incidentId,
+        "status": "Actualizado",
+        "message": "Incidencia actualizada correctamente.",
+    }
+
+
+if __name__ == "__main__":
+    mcp.run("streamable-http")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic
 pytest
 pytest-asyncio
 python-dotenv
+mcp[cli]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,9 @@
+import os
+import sys
 import pytest
 from httpx import AsyncClient, ASGITransport
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from mcp_server.main import app
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `mcp[cli]` dependency
- implement an MCP server with FastMCP
- adjust tests to ensure local package is discoverable
- update README with instructions for the new server

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845f7ce32b48326a698fa817d0e8b9c